### PR TITLE
fix(converters): correct lightgbm typo

### DIFF
--- a/onnx-ecosystem/converter_scripts/lightgbm_onnx.ipynb
+++ b/onnx-ecosystem/converter_scripts/lightgbm_onnx.ipynb
@@ -30,7 +30,7 @@
    "outputs": [],
    "source": [
     "# Load your LightGBM model\n",
-    "lgb_model = lgb.Booster(model_file='mode.txt')\n",
+    "lgb_model = lgb.Booster(model_file='model.txt')\n",
     "\n",
     "# Convert the LightGBM model into ONNX\n",
     "onnx_model = onnxmltools.convert_lightgbm(lgb_model)\n",


### PR DESCRIPTION
This is a really simple commit that fixes lightgbm_onnx.ipynb to change
the typo of `mode.txt` to read `model.txt`.

DCO 1.1 Signed-off-by: Patrick Wagstrom <patrick@wagstrom.net>