### PR TITLE
Correct variable name in keras_onnx.ipynb

### DIFF
--- a/onnx-ecosystem/converter_scripts/keras_onnx.ipynb
+++ b/onnx-ecosystem/converter_scripts/keras_onnx.ipynb
@@ -33,7 +33,7 @@
     "keras_model = load_model(input_keras_model)\n",
     "\n",
     "# Convert the Keras model into ONNX\n",
-    "onnx_model = onnxmltools.convert_keras(model)\n",
+    "onnx_model = onnxmltools.convert_keras(keras_model)\n",
     "\n",
     "# Save as protobuf\n",
     "onnxmltools.utils.save_model(onnx_model, output_onnx_model)"


### PR DESCRIPTION
`onnxmltools.convert_keras` was supplied model as a parameter. However, this variable does not exist. Logically, `keras_model` is the correct substitute.