### PR TITLE
bump pillow version

### DIFF
--- a/onnx-ecosystem/requirements.txt
+++ b/onnx-ecosystem/requirements.txt
@@ -4,7 +4,7 @@ six==1.11.0
 opencv-python==3.2.0.6
 matplotlib==2.1.1
 pandas==0.24.0
-pillow==7.0.0
+pillow==7.1.0
 scipy==1.0.0
 setuptools==41.0.0
 


### PR DESCRIPTION
per security alert : https://github.com/advisories/GHSA-43fq-w8qq-v88h
Out-of-bounds read in Pillow for versions < 7.1.0
Patched version 7.1.0