### PR TITLE
fix : requirements.txt

### DIFF
--- a/onnx-ecosystem/requirements.txt
+++ b/onnx-ecosystem/requirements.txt
@@ -19,8 +19,8 @@ skl2onnx
 
 tf2onnx
 
-torchvision==0.5.0
-torch==1.5.1
+torchvision==0.7.0
+torch==1.6.0
 
 xgboost==0.81
 


### PR DESCRIPTION
There is version conflict between torch and torch-vision 

This conflict causes build error.
Version of torch is 1.5.1 but this version cannot match with torch-vision version 0.5.0 

In python >= 3.6, you may use your torch version 1.6.0 and torch-vision 0.7.0

So I changed it and rebuild, It works!