### PR TITLE
Providing GPU enabled docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@ To store the docker BUILD scripts of ONNX related docker images.
 - [onnx-base](onnx-base): Use published ONNX package from PyPi with minimal dependencies.
 - [onnx-dev](onnx-dev): Build ONNX from source with minimal dependencies.
 - [onnx-ecosystem](onnx-ecosystem): Jupyter notebook environment for getting started quickly with ONNX models, ONNX converters, and inference using ONNX Runtime.
+- [onnxruntime-gpu-1.6-python](onnxruntime-gpu1.6-python): CUDA 10.2 / onnxruntime-gpu 1.6 docker for python.
+- [onnxruntime-gpu-1.7-python](onnxruntime-gpu1.7-python): CUDA 11.0.3 / onnxruntime-gpu 1.7 docker for python.
+- [onnxruntime-gpu-1.6-c](onnxruntime-gpu1.6-c): CUDA 10.2 / onnxruntime-gpu 1.6 docker for c.
+- [onnxruntime-gpu-1.7-c](onnxruntime-gpu1.7-c): CUDA 11.0.3 / onnxruntime-gpu 1.7 docker for c.
 
 ## Docker Image Workflow
 
 1. Obtain the Docker images
 
-  You can clone this repository and build your desired image.
+You can clone this repository and build your desired image.
+
   ```
   # onnx-base container
   cd onnx-base
@@ -24,9 +29,14 @@ To store the docker BUILD scripts of ONNX related docker images.
   # onnx-ecosystem container
   cd onnx-ecosystem
   docker build . -t onnx-ecosystem
+
+  # onnxruntime-gpu1.6-python container
+  cd onnxruntime-gpu1.6-python
+  docker build . -t onnxruntime-gpu1.6-python
   ```
 
-  Alternatively, you can pull a pre-built image from [DockerHub](https://hub.docker.com/u/onnx).
+Alternatively, you can pull a pre-built image from [DockerHub](https://hub.docker.com/u/onnx).
+
   ```
   docker pull onnx/onnx-base
   docker pull onnx/onnx-dev
@@ -41,4 +51,5 @@ docker images
 docker run -it onnx-base
 docker run -it onnx-dev
 docker run -p 8888:8888 onnx-ecosystem
+docker run --gpus all -it --ipc=host onnxruntime-gpu1.6-python
 ```

--- a/onnxruntime-gpu1.6-c/Dockerfile
+++ b/onnxruntime-gpu1.6-c/Dockerfile
@@ -1,0 +1,15 @@
+FROM nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04
+
+LABEL maintainer Xavier Tao "tao.xavier@outlook.com" 
+
+# Get Onnruntime gpu 1.6.0
+ADD https://github.com/microsoft/onnxruntime/releases/download/v1.6.0/onnxruntime-linux-x64-gpu-1.6.0.tgz  /usr/local/
+
+# Get Onnruntime gpu 1.6.0
+RUN cd /usr/local/ && \
+    tar -xf onnxruntime-linux-x64-gpu-1.6.0.tgz && \
+    rm onnxruntime-linux-x64-gpu-1.6.0.tgz
+
+ENV LD_LIBRARY_PATH=/usr/local/onnxruntime-linux-x64-gpu-1.6.0/lib:${LD_LIBRARY_PATH}
+
+ENTRYPOINT ["/bin/bash"]

--- a/onnxruntime-gpu1.6-python/Dockerfile
+++ b/onnxruntime-gpu1.6-python/Dockerfile
@@ -1,0 +1,31 @@
+FROM nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04
+
+LABEL maintainer Xavier Tao "tao.xavier@outlook.com" 
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ccache \
+    cmake \
+    git \
+    vim \
+    libprotoc-dev \
+    protobuf-compiler \
+    curl \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH /opt/conda/bin:$PATH
+
+ARG PYTHON_VERSION=3.8
+RUN curl -fsSL -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} conda-build pyyaml numpy && \
+    /opt/conda/bin/conda clean -ya
+
+RUN pip install onnxruntime==1.6.0 onnxruntime-gpu==1.6.0 
+
+ENTRYPOINT ["/bin/bash"]

--- a/onnxruntime-gpu1.7-c/Dockerfile
+++ b/onnxruntime-gpu1.7-c/Dockerfile
@@ -1,0 +1,17 @@
+FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu20.04
+
+LABEL maintainer Xavier Tao "tao.xavier@outlook.com" 
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Get Onnruntime gpu 1.7.0
+ADD https://github.com/microsoft/onnxruntime/releases/download/v1.7.0/onnxruntime-linux-x64-gpu-1.7.0.tgz  /usr/local/
+
+# Get Onnruntime gpu 1.7.0
+RUN cd /usr/local/ && \
+    tar -xf onnxruntime-linux-x64-gpu-1.7.0.tgz && \
+    rm onnxruntime-linux-x64-gpu-1.7.0.tgz 
+
+ENV LD_LIBRARY_PATH=/usr/local/onnxruntime-linux-x64-gpu-1.7.0/lib:${LD_LIBRARY_PATH}
+
+ENTRYPOINT ["/bin/bash"]

--- a/onnxruntime-gpu1.7-python/Dockerfile
+++ b/onnxruntime-gpu1.7-python/Dockerfile
@@ -1,0 +1,31 @@
+FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu20.04
+
+LABEL maintainer Xavier Tao "tao.xavier@outlook.com" 
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ccache \
+    cmake \
+    git \
+    vim \
+    libprotoc-dev \
+    protobuf-compiler \
+    curl \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH /opt/conda/bin:$PATH
+
+ARG PYTHON_VERSION=3.8
+RUN curl -fsSL -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} conda-build pyyaml numpy && \
+    /opt/conda/bin/conda clean -ya
+
+RUN pip install onnxruntime==1.7.0 onnxruntime-gpu==1.7.0 
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Providing CUDA and CUDNN driver within docker image simplify
compatibility issues.

This is especially true for onnxruntime 1.6 and 1.7 depending
respectively on CUDA 10 and 11.

Those images does not try to minimize the image size. I'll be happy to
add any simple optimization. But, as ML and DL tend to be heavy in size
I believe simplicity is probably more interesting than size.