### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# [Notice] We have stopped development of onnx-docker. This repo and related DockerHub won't be updated anymore. To install newer ONNX, please check [the document](https://github.com/onnx/onnx#installation) in the onnx repo.
-
 <!--- SPDX-License-Identifier: Apache-2.0 -->
+
+# [<b>Notice</b>] We have stopped development of onnx-docker. This repo and related DockerHub won't be updated anymore. To install newer ONNX, you can get it from [PyPI](https://pypi.org/project/onnx/) or [conda-forge](https://anaconda.org/conda-forge/onnx). For more installation details, please check the [README.md](https://github.com/onnx/onnx#installation) in the onnx repo.
 
 # What is this repository for?
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Notice] We have stopped development of onnx-docker. This repo and related DockerHub won't be updated anymore.
+# [Notice] We have stopped development of onnx-docker. This repo and related DockerHub won't be updated anymore. To install newer ONNX, please check [the document](https://github.com/onnx/onnx#installation) in the onnx repo.
 
 <!--- SPDX-License-Identifier: Apache-2.0 -->
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# [Notice] We have stopped development of onnx-docker. This repo and related DockerHub won't be updated anymore.
+
 <!--- SPDX-License-Identifier: Apache-2.0 -->
 
 # What is this repository for?


### PR DESCRIPTION
ONNX steering committee decided to deprecate onnx-docker. See [more details](https://lfaifoundation.slack.com/archives/C016NJDAWVC/p1660337770798499) from Slack. Therefore add a notice in README.md

cc @prasanthpul